### PR TITLE
Refactor buddies to users

### DIFF
--- a/geekzbay/app/Http/Controllers/CommunityController.php
+++ b/geekzbay/app/Http/Controllers/CommunityController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CommunityController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/geekzbay/app/Http/Controllers/CommunityController.php
+++ b/geekzbay/app/Http/Controllers/CommunityController.php
@@ -14,6 +14,7 @@ class CommunityController extends Controller
     public function index()
     {
         //
+        return view('layouts.my-communities');
     }
 
     /**
@@ -43,9 +44,10 @@ class CommunityController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(/*$id*/)
     {
         //
+        return view('layouts.community');
     }
 
     /**

--- a/geekzbay/app/Http/Controllers/EventController.php
+++ b/geekzbay/app/Http/Controllers/EventController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class EventController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/geekzbay/app/Http/Controllers/EventController.php
+++ b/geekzbay/app/Http/Controllers/EventController.php
@@ -14,6 +14,7 @@ class EventController extends Controller
     public function index()
     {
         //
+        return view('layouts.my-meetups');
     }
 
     /**
@@ -43,9 +44,10 @@ class EventController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(/*$id*/)
     {
         //
+        return view('layouts.meetup');
     }
 
     /**

--- a/geekzbay/app/Http/Controllers/PlaceController.php
+++ b/geekzbay/app/Http/Controllers/PlaceController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PlaceController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/geekzbay/app/Http/Controllers/PlaceController.php
+++ b/geekzbay/app/Http/Controllers/PlaceController.php
@@ -14,6 +14,7 @@ class PlaceController extends Controller
     public function index()
     {
         //
+        return view('layouts.my-locations');
     }
 
     /**
@@ -43,9 +44,10 @@ class PlaceController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(/*$id*/)
     {
         //
+        return view('layouts.locations');
     }
 
     /**

--- a/geekzbay/app/Http/Controllers/UserController.php
+++ b/geekzbay/app/Http/Controllers/UserController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/geekzbay/app/Http/Controllers/UserController.php
+++ b/geekzbay/app/Http/Controllers/UserController.php
@@ -14,6 +14,7 @@ class UserController extends Controller
     public function index()
     {
         //
+        return view('layouts.my-buddies');
     }
 
     /**
@@ -43,9 +44,10 @@ class UserController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(/*$id*/)
     {
         //
+        return view('layouts.buddy');
     }
 
     /**

--- a/geekzbay/database/migrations/2022_09_14_120451_create_users_in_communities.php
+++ b/geekzbay/database/migrations/2022_09_14_120451_create_users_in_communities.php
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('buddies_in_communities');
+        Schema::dropIfExists('users_in_communities');
     }
 };

--- a/geekzbay/database/migrations/2022_09_14_121028_users_in_events.php
+++ b/geekzbay/database/migrations/2022_09_14_121028_users_in_events.php
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('buddies_in_events');
+        Schema::dropIfExists('users_in_events');
     }
 };

--- a/geekzbay/routes/web.php
+++ b/geekzbay/routes/web.php
@@ -1,6 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CommunityController;
+use App\Http\Controllers\EventController;
+use App\Http\Controllers\PlaceController;
+use App\Http\Controllers\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,39 +18,31 @@ use Illuminate\Support\Facades\Route;
 */
 
 //content pages
+
+// Buddies
+Route::get('/buddy', [UserController::class, 'show'])->name('buddy');
+Route::get('/buddy/my-buddies', [UserController::class, 'index'])->name('my-buddies');
+// Meetups
+Route::get('/meetup', [EventController::class, 'show'])->name('meetup');
+Route::get('/meetup/my-meetups', [EventController::class, 'index'])->name('my-meetups');
+// Communities
+Route::get('/community', [CommunityController::class, 'show'])->name('community');
+Route::get('/community/my-communities',[CommunityController::class, 'index'])->name('my-communities');
+// Locations
+Route::get('locations', [PlaceController::class, 'show'])->name('locations');
+Route::get('/locations/my-locations', [PlaceController::class, 'index'])->name('my-locations');
+
+
 Route::get('/', function () {
     return view('layouts.home');
 })->name('home');
-Route::get('/buddy', function () {
-    return view('layouts.buddy');
-})->name('buddy');
-Route::get('/meetup', function () {
-    return view('layouts.meetup');
-})->name('meetup');
-Route::get('/community', function () {
-    return view('layouts.community');
-})->name('community');
-Route::get('/locations', function () {
-    return view('layouts.locations');
-})->name('locations');
 
 
 //account access pages
 Route::get('/profile', function () {
     return view('layouts.profile');
 })->name('profile');
-Route::get('/buddy/my-buddies', function () {
-    return view('layouts.my-buddies');
-})->name('my-buddies');
-Route::get('/meetup/my-meetups', function () {
-    return view('layouts.my-meetups');
-})->name('my-meetups');
-Route::get('/community/my-communities', function () {
-    return view('layouts.my-communities');
-})->name('my-communities');
-Route::get('/locations/my-locations', function () {
-    return view('layouts.my-locations');
-})->name('my-locations');
+
 
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
- Fixes the down method of most user tables, as I forgot to change it to buddy.
- Adds controllers for showing sites instead of routing the view directly to the router.

The problem is we need to talk about when we index multiple profiles for communities/buddies(or users)/events. If it's the general one, we should probably redirect it to a searchpage, except it's preset to searching for what we linked to.
Also, had to comment out the id on show because we don't have anything to show right now. Gotta do the seeders.